### PR TITLE
replacement for wrap-edn-params

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,6 @@
                  [ring "1.3.2"]
                  [compojure "1.3.1"]
                  [figwheel "0.2.4-SNAPSHOT"]
-                 [fogus/ring-edn "0.2.0"]
                  [com.datomic/datomic-free "0.9.5130" :exclusions [joda-time]]]
 
   :plugins [[lein-cljsbuild "1.0.4"]

--- a/src/clj/om_async/core.clj
+++ b/src/clj/om_async/core.clj
@@ -1,11 +1,11 @@
 (ns om-async.core
   (:require [ring.util.response :refer [file-response]]
             [ring.adapter.jetty :refer [run-jetty]]
-            [ring.middleware.edn :refer [wrap-edn-params]]
             [compojure.core :refer [defroutes GET PUT POST]]
             [compojure.route :as route]
             [compojure.handler :as handler]
-            [datomic.api :as d]))
+            [datomic.api :as d]
+            [clojure.edn :as edn]))
 
 (def uri "datomic:free://localhost:4334/om_async")
 (def conn (d/connect uri))

--- a/src/clj/om_async/core.clj
+++ b/src/clj/om_async/core.clj
@@ -57,6 +57,19 @@
   (PUT "/classes" {params :edn-params} (update-class params))
   (route/files "/" {:root "resources/public"}))
 
-(def handler 
+(defn read-inputstream-edn [input]
+  (edn/read
+   {:eof nil}
+   (java.io.PushbackReader.
+    (java.io.InputStreamReader. input "UTF-8"))))
+
+(defn parse-edn-body [handler]
+  (fn [request]
+    (handler (if-let [body (:body request)]
+               (assoc request
+                 :body-edn (read-inputstream-edn body))
+               request))))
+
+(def handler
   (-> routes
-      wrap-edn-params))
+      parse-edn-body))

--- a/src/clj/om_async/core.clj
+++ b/src/clj/om_async/core.clj
@@ -53,8 +53,8 @@
   (GET "/" [] (index))
   (GET "/init" [] (init))
   (GET "/classes" [] (classes))
-  (POST "/classes" {params :body-edn} (create-class params))
-  (PUT "/classes" {params :body-edn} (update-class params))
+  (POST "/classes" {params :edn-body} (create-class params))
+  (PUT "/classes" {params :edn-body} (update-class params))
   (route/files "/" {:root "resources/public"}))
 
 (defn read-inputstream-edn [input]
@@ -67,7 +67,7 @@
   (fn [request]
     (handler (if-let [body (:body request)]
                (assoc request
-                 :body-edn (read-inputstream-edn body))
+                 :edn-body (read-inputstream-edn body))
                request))))
 
 (def handler

--- a/src/clj/om_async/core.clj
+++ b/src/clj/om_async/core.clj
@@ -53,8 +53,8 @@
   (GET "/" [] (index))
   (GET "/init" [] (init))
   (GET "/classes" [] (classes))
-  (POST "/classes" {params :edn-params} (create-class params))
-  (PUT "/classes" {params :edn-params} (update-class params))
+  (POST "/classes" {params :body-edn} (create-class params))
+  (PUT "/classes" {params :body-edn} (update-class params))
   (route/files "/" {:root "resources/public"}))
 
 (defn read-inputstream-edn [input]


### PR DESCRIPTION
This works around the assumption in 'ring.middleware.edn/wrap-edn-params that the (:body request) will be a map.
